### PR TITLE
Bumped SASS_NPM_VERSION up to 3.4.2 

### DIFF
--- a/coffee-mill-maven-plugin/src/main/java/org/nanoko/coffeemill/mojos/stylesheets/sass/SassCompilerMojo.java
+++ b/coffee-mill-maven-plugin/src/main/java/org/nanoko/coffeemill/mojos/stylesheets/sass/SassCompilerMojo.java
@@ -28,7 +28,7 @@ defaultPhase = LifecyclePhase.COMPILE)
 public class SassCompilerMojo extends AbstractCoffeeMillWatcherMojo {
 
     public static final String SASS_NPM_NAME = "node-sass";
-    public static final String SASS_NPM_VERSION = "0.8.1";
+    public static final String SASS_NPM_VERSION = "3.4.2";
 
     private NPM sass;
 


### PR DESCRIPTION
Hi all,

today I am sending you this pull request.

I am currently evaluating your coffee-mill-maven-plugin and would like to know, if you are still supporting it. We would very much like to use it in one of our web-projects.

I have an issue with coffee-mill-maven-plugin version 1.1.4. It makes use of the node package node-sass@0.8.1. Version 0.8.1 quite old. The current version is 3.4.2.

The problem is that 0.8.1 does not compile on newer windows machines, which practically breaks your plugin on our development machines.

We have tested the plugin with node-sass@3.4.2 and it seems to work just fine.

Best regards from Hamburg, Germany
Jan Weinschenker